### PR TITLE
fix: missing wasm tx context

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -54,6 +54,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		wasmkeeper.NewLimitSimulationGasDecorator(options.NodeConfig.SimulationGasLimit),
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
+		wasmkeeper.NewTxContractsDecorator(),
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),


### PR DESCRIPTION
Missing ante handler for wasm tx context results in warning logs shown
```
WRN cannot get tx contracts from context module=x/wasm
```